### PR TITLE
[codex] Improve URL matching accuracy, international text handling, and performance

### DIFF
--- a/addon/globalPlugins/openLinkWith/__init__.py
+++ b/addon/globalPlugins/openLinkWith/__init__.py
@@ -8,7 +8,8 @@
 import globalPluginHandler
 import webbrowser
 import subprocess
-import gui, wx
+import gui
+import wx
 from gui import guiHelper
 import config
 import globalVars
@@ -20,6 +21,7 @@ import textInfos
 from .mydialog import MyDialog, browsersGoPrivate
 from .getlinks import LastSpoken, getLinksFromSelectedText, getLinksFromClipboard, getLinksFromLastSpoken
 from .getbrowsers import getBrowsers
+from .urlUtils import isSupportedUrl
 from scriptHandler import script
 from logHandler import log
 
@@ -47,7 +49,7 @@ def getLinkObj():
 		log.debugWarning("Unable to get the caret position.", exc_info=True)
 		ti: textInfos.TextInfo = api.getFocusObject().makeTextInfo(textInfos.POSITION_FIRST)
 	ti.expand(textInfos.UNIT_CHARACTER)
-	obj: NVDAObject = ti.NVDAObjectAtStart
+	obj = ti.NVDAObjectAtStart
 	if (
 		obj.role == controlTypes.role.Role.GRAPHIC
 		and (
@@ -137,7 +139,7 @@ class VirtualMenu():
 				subprocess.Popen([exePath,flag, cls.url])
 			else:
 				subprocess.Popen(exePath+' '+cls.url)
-		except:
+		except Exception:
 			# Translators: Message displayed if error happens in activating a menu item.
 			message= _("Error in opening the link with {item} browser").format(item= cls.menuItems[cls.index])
 			wx.CallAfter(gui.messageBox, message,
@@ -182,7 +184,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		else:
 			try:
 				self.prefmenu.RemoveItem(self.addonmenu)
-			except :
+			except Exception:
 				pass
 
 	@script(
@@ -256,8 +258,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		linkDestination = obj.value
 		# It is a link, but may be it's value is an email or other thing that shouldn't be opened with a browser.
-		import re
-		if linkDestination and not re.match(r'https?://|ftp://|www.', linkDestination):
+		if linkDestination and not isSupportedUrl(linkDestination):
 			# Translators: Message display if the link is not suited to open with the browser.
 			message= _("The link {linkValue} is not suitable to open with the browser").format(linkValue= linkDestination)
 			wx.CallAfter(gui.messageBox, message,

--- a/addon/globalPlugins/openLinkWith/getbrowsers.py
+++ b/addon/globalPlugins/openLinkWith/getbrowsers.py
@@ -4,7 +4,6 @@
 #This module is aimed to get several browsers if found in the registry and their path.
 
 import os
-import sys
 
 # for compatibility with python3
 try:

--- a/addon/globalPlugins/openLinkWith/getlinks.py
+++ b/addon/globalPlugins/openLinkWith/getlinks.py
@@ -3,10 +3,12 @@
 # Code to get last spoken text is borrowed from speechHistory addon, thanks to James Scholes, Tyler Spivey and all contributors to that addon.
 
 import textInfos
-import re
-import api, ui
+import api
+import ui
 import speech
 import speechViewer
+
+from .urlUtils import findUrls
 
 import addonHandler
 addonHandler.initTranslation()
@@ -31,15 +33,6 @@ class LastSpoken:
 		if text.strip():
 			cls.lastSpokenText=text.strip()
 
-
-def find_urls (text):
-	"""Find URLs in a text string.
-	"""
-	url_re = re.compile(r"(?:https?://|ftp://|www.)[^ ,.?!#%=+][^ ][^ \t\n\r\f\v]*")
-	bad_chars = '\'\\.,[](){}:;"'
-	links= [s.strip(bad_chars) for s in url_re.findall(text)]
-	# remove duplicates
-	return list(dict.fromkeys(links))
 
 def getClipText() -> str:
 	try:
@@ -72,7 +65,7 @@ def getLinksFromSelectedText():
 		return
 	else:
 		text= isSelectedText()
-		links=find_urls(text)
+		links=findUrls(text)
 		if not links:
 			# Translators: Displayed if there is no links in selected text.
 			ui.message(_("no links in selected text"))
@@ -88,7 +81,7 @@ def getLinksFromClipboard():
 		ui.message(_("No text in clipboard."))
 		return
 	else:
-		links=find_urls(text)
+		links=findUrls(text)
 		if not links:
 			# Translators: Message displayed when there is no links in clipboard text.
 			ui.message(_("No links in clipboard text."))
@@ -104,7 +97,7 @@ def getLinksFromLastSpoken():
 		ui.message(_("No text."))
 		return
 	else:
-		links=find_urls(text)
+		links=findUrls(text)
 		if not links:
 			# Translators: Message displayed when there is no links in last spoken text.
 			ui.message(_("No links in last spoken text."))

--- a/addon/globalPlugins/openLinkWith/mydialog.py
+++ b/addon/globalPlugins/openLinkWith/mydialog.py
@@ -2,11 +2,8 @@
 
 import wx
 import config
-import os 
 import webbrowser 
 import subprocess 
-from .getbrowsers import getBrowsers
-from logHandler import log
 import addonHandler
 addonHandler.initTranslation()
 
@@ -61,7 +58,7 @@ class MyDialog(wx.Dialog):
 		self.Show()
  
 	def checkCloseAfterActivatingLink(self):
-		if config.conf["openLinkWith"]["closeDialogAfterActivatingALink"]== True:
+		if config.conf["openLinkWith"]["closeDialogAfterActivatingALink"]:
 			wx.CallLater(4000, self.Destroy)
 
 	def onOpen(self, evt, exe_path):

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -9,10 +9,12 @@ from urllib.parse import urlsplit
 
 _URL_PREFIX_PATTERN = re.compile(r"(?:https?://|ftp://|www\.)", re.IGNORECASE)
 _INVALID_INITIAL_URL_CHARACTERS = frozenset(",.?!#%=+")
-_URL_TERMINATOR_PATTERN = re.compile(
-	r'[\s\x00-\x1f\x7f-\x9f<>"\\^`{|}'
-	r"\u061c\u200b\u200e-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u206f\ufeff\uff5c]"
+_URL_TERMINATOR_CHARACTER_CLASS = (
+	r'\s\x00-\x1f\x7f-\x9f<>"\\^`{|}'
+	r"\u061c\u200b\u200e-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u206f\ufeff\uff5c"
 )
+_URL_TERMINATOR_PATTERN = re.compile(rf"[{_URL_TERMINATOR_CHARACTER_CLASS}]")
+_AUTHORITY_END_PATTERN = re.compile(rf"[/?#{_URL_TERMINATOR_CHARACTER_CLASS}]")
 _INVALID_PERCENT_ESCAPE_PATTERN = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _HOSTNAME_PUNCTUATION_CHARACTERS = frozenset(
 	".-_%\u00b7\u0375\u05f3\u05f4\u200c\u200d\u3002\u30fb\uff0d\uff0e\uff3f\uff61"
@@ -55,89 +57,74 @@ _TRIMMABLE_TRAILING_CHARACTERS = (
 )
 
 
-def _isUrlTerminator(character: str) -> bool:
-	"""Return whether a character definitely ends a raw URL candidate."""
-	return _URL_TERMINATOR_PATTERN.fullmatch(character) is not None
-
-
 def _hasValidUrlStart(text: str, prefixEnd: int) -> bool:
 	"""Return whether a supported prefix is followed by a possible URL character."""
 	return (
 		prefixEnd < len(text)
 		and text[prefixEnd] not in _INVALID_INITIAL_URL_CHARACTERS
-		and not _isUrlTerminator(text[prefixEnd])
+		and _URL_TERMINATOR_PATTERN.fullmatch(text[prefixEnd]) is None
 	)
 
 
 def _isAllowedHostnameCharacter(character: str) -> bool:
 	"""Return whether a raw character can be part of a browser-facing hostname."""
-	if character in _HOSTNAME_PUNCTUATION_CHARACTERS:
-		return True
 	# cmark-gfm and linkify-it admit Unicode symbols as well as letters, marks, and numbers.
-	return unicodedata.category(character)[0] in "LMNS"
+	return character in _HOSTNAME_PUNCTUATION_CHARACTERS or unicodedata.category(character)[0] in "LMNS"
 
 
 def _isAllowedUserinfoCharacter(character: str) -> bool:
 	"""Return whether a raw character can occur before an authority's final at sign."""
 	if not character.isascii():
-		return not _isUrlTerminator(character)
+		return _URL_TERMINATOR_PATTERN.fullmatch(character) is None
 	return character.isalnum() or character in _ASCII_USERINFO_CHARACTERS
 
 
-def _truncateAtAuthorityBoundary(url: str) -> str:
-	"""Stop a URL candidate at prose punctuation in its hostname or port."""
-	authorityStart = 0 if url[:4].casefold() == "www." else url.find("://") + 3
-	authorityEnd = len(url)
-	for separator in "/?#":
-		separatorIndex = url.find(separator, authorityStart)
-		if separatorIndex >= 0:
-			authorityEnd = min(authorityEnd, separatorIndex)
-	userinfoEnd = url.rfind("@", authorityStart, authorityEnd)
+def _findAuthorityEnd(text: str, prefixEnd: int) -> int:
+	"""Return the position where a URL authority ends."""
+	match = _AUTHORITY_END_PATTERN.search(text, prefixEnd)
+	return match.start() if match is not None else len(text)
+
+
+def _findAuthorityBoundary(text: str, urlStart: int, prefixEnd: int, authorityEnd: int) -> int:
+	"""Return the first prose boundary within a URL authority."""
+	authorityStart = urlStart if text[urlStart:prefixEnd].casefold() == "www." else prefixEnd
+	userinfoEnd = text.rfind("@", authorityStart, authorityEnd)
 	if userinfoEnd >= 0:
 		for index in range(authorityStart, userinfoEnd):
-			if not _isAllowedUserinfoCharacter(url[index]):
-				return url[:index]
+			if not _isAllowedUserinfoCharacter(text[index]):
+				return index
 	hostnameStart = userinfoEnd + 1 if userinfoEnd >= 0 else authorityStart
 	if hostnameStart >= authorityEnd:
-		return url
+		return authorityEnd
 
-	if url[hostnameStart] == "[":
-		closingBracket = url.find("]", hostnameStart + 1, authorityEnd)
+	if text[hostnameStart] == "[":
+		closingBracket = text.find("]", hostnameStart + 1, authorityEnd)
 		if closingBracket < 0:
-			return url
+			return authorityEnd
 		hostnameEnd = closingBracket + 1
 	else:
-		portSeparator = url.find(":", hostnameStart, authorityEnd)
+		portSeparator = text.find(":", hostnameStart, authorityEnd)
 		hostnameEnd = portSeparator if portSeparator >= 0 else authorityEnd
 		for index in range(hostnameStart, hostnameEnd):
-			if not _isAllowedHostnameCharacter(url[index]):
-				return url[:index]
+			if not _isAllowedHostnameCharacter(text[index]):
+				return index
 
 	if hostnameEnd >= authorityEnd:
-		return url
-	portStart = hostnameEnd + 1 if url[hostnameEnd] == ":" else hostnameEnd
+		return authorityEnd
+	portStart = hostnameEnd + 1 if text[hostnameEnd] == ":" else hostnameEnd
 	for index in range(portStart, authorityEnd):
-		if not _isAllowedHostnameCharacter(url[index]):
-			return url[:index]
-	return url
+		if not _isAllowedHostnameCharacter(text[index]):
+			return index
+	return authorityEnd
 
 
 def _findUrlCandidateEnd(text: str, urlStart: int, prefixEnd: int) -> int:
 	"""Return the end of one URL candidate without scanning later candidates."""
-	authorityEnd = len(text)
-	for separator in "/?#":
-		separatorIndex = text.find(separator, prefixEnd)
-		if separatorIndex >= 0:
-			authorityEnd = min(authorityEnd, separatorIndex)
-	terminatorMatch = _URL_TERMINATOR_PATTERN.search(text, prefixEnd, authorityEnd)
-	if terminatorMatch is not None:
-		authorityEnd = terminatorMatch.start()
-
-	authorityCandidate = text[urlStart:authorityEnd]
-	truncatedAuthority = _truncateAtAuthorityBoundary(authorityCandidate)
-	if len(truncatedAuthority) < len(authorityCandidate):
-		return urlStart + len(truncatedAuthority)
-	if authorityEnd >= len(text) or _isUrlTerminator(text[authorityEnd]):
+	authorityEnd = _findAuthorityEnd(text, prefixEnd)
+	authorityBoundary = _findAuthorityBoundary(text, urlStart, prefixEnd, authorityEnd)
+	if authorityBoundary < authorityEnd:
+		return authorityBoundary
+	if authorityEnd >= len(text) or text[authorityEnd] not in "/?#":
 		return authorityEnd
 
 	precedingCharacter = text[urlStart - 1] if urlStart else ""
@@ -183,26 +170,17 @@ def _trimUrlEnd(url: str) -> str:
 	if suffixStart == len(url):
 		return url
 
-	delimiterBalance = {opening: 0 for opening in _CLOSING_TO_OPENING_DELIMITERS.values()}
-	for index in range(suffixStart):
-		character = url[index]
-		if character in delimiterBalance:
-			delimiterBalance[character] += 1
-		elif character in _CLOSING_TO_OPENING_DELIMITERS:
-			opening = _CLOSING_TO_OPENING_DELIMITERS[character]
-			if delimiterBalance[opening]:
-				delimiterBalance[opening] -= 1
-
+	delimiterBalance = dict.fromkeys(_OPENING_TO_CLOSING_DELIMITERS, 0)
 	endIndex = suffixStart
-	for index in range(suffixStart, len(url)):
-		character = url[index]
+	for index, character in enumerate(url):
 		if character in delimiterBalance:
 			delimiterBalance[character] += 1
 		elif character in _CLOSING_TO_OPENING_DELIMITERS:
 			opening = _CLOSING_TO_OPENING_DELIMITERS[character]
 			if delimiterBalance[opening]:
 				delimiterBalance[opening] -= 1
-				endIndex = index + 1
+				if index >= suffixStart:
+					endIndex = index + 1
 	return url[:endIndex]
 
 
@@ -231,12 +209,13 @@ def findUrls(text: str) -> list[str]:
 def isSupportedUrl(url: str) -> bool:
 	"""Return whether the entire string is a supported URL."""
 	prefixMatch = _URL_PREFIX_PATTERN.match(url)
+	if prefixMatch is None or not _hasValidUrlStart(url, prefixMatch.end()):
+		return False
+	authorityEnd = _findAuthorityEnd(url, prefixMatch.end())
 	if (
-		prefixMatch is None
-		or not _hasValidUrlStart(url, prefixMatch.end())
-		or _URL_TERMINATOR_PATTERN.search(url) is not None
+		_URL_TERMINATOR_PATTERN.search(url) is not None
 		or _INVALID_PERCENT_ESCAPE_PATTERN.search(url)
-		or _truncateAtAuthorityBoundary(url) != url
+		or _findAuthorityBoundary(url, 0, prefixMatch.end(), authorityEnd) != authorityEnd
 	):
 		return False
 	hasBareWwwPrefix = url[:4].casefold() == "www."

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -1,43 +1,75 @@
 """Utilities for matching URLs supported by Open Link With."""
 
+from __future__ import annotations
+
 import re
+from urllib.parse import urlsplit
 
 
-_BAD_URL_END_CHARACTERS = "'\\.,[](){}:;\""
+_URL_TERMINATOR_PATTERN = r'\s\x00-\x1f\x7f-\x9f<>"\\^`{|}'
 _URL_PATTERN = re.compile(
-	r'(?:https?://|ftp://|www\.)[^ ,.?!#%=+<>"\\][^\s<>"\\]*',
+	rf"(?:https?://|ftp://|www\.)"
+	rf"[^,.?!#%=+{_URL_TERMINATOR_PATTERN}]"
+	rf"[^{_URL_TERMINATOR_PATTERN}]*",
 	re.IGNORECASE,
 )
+_INVALID_PERCENT_ESCAPE_PATTERN = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_UNCONDITIONAL_TRAILING_CHARACTERS = "'.,[(:;"
+_CLOSING_TO_OPENING_DELIMITERS = {")": "(", "]": "["}
+_TRIMMABLE_TRAILING_CHARACTERS = _UNCONDITIONAL_TRAILING_CHARACTERS + "".join(_CLOSING_TO_OPENING_DELIMITERS)
+
+
+def _trimUrlEnd(url: str) -> str:
+	"""Trim prose punctuation while preserving balanced URL delimiters."""
+	suffixStart = len(url)
+	while suffixStart and url[suffixStart - 1] in _TRIMMABLE_TRAILING_CHARACTERS:
+		suffixStart -= 1
+
+	delimiterBalance = {opening: 0 for opening in _CLOSING_TO_OPENING_DELIMITERS.values()}
+	for index in range(suffixStart):
+		character = url[index]
+		if character in delimiterBalance:
+			delimiterBalance[character] += 1
+		elif character in _CLOSING_TO_OPENING_DELIMITERS:
+			opening = _CLOSING_TO_OPENING_DELIMITERS[character]
+			if delimiterBalance[opening]:
+				delimiterBalance[opening] -= 1
+
+	endIndex = suffixStart
+	for index in range(suffixStart, len(url)):
+		character = url[index]
+		if character in delimiterBalance:
+			delimiterBalance[character] += 1
+		elif character in _CLOSING_TO_OPENING_DELIMITERS:
+			opening = _CLOSING_TO_OPENING_DELIMITERS[character]
+			if delimiterBalance[opening]:
+				delimiterBalance[opening] -= 1
+				endIndex = index + 1
+	return url[:endIndex]
 
 
 def findUrls(text: str) -> list[str]:
 	"""Return unique supported URLs found in text, preserving their order."""
-	return list(
-		dict.fromkeys(match.group(0).strip(_BAD_URL_END_CHARACTERS) for match in _URL_PATTERN.finditer(text))
-	)
+	urls: list[str] = []
+	seenUrls: set[str] = set()
+	for match in _URL_PATTERN.finditer(text):
+		url = _trimUrlEnd(match.group(0))
+		if url in seenUrls or not isSupportedUrl(url):
+			continue
+		seenUrls.add(url)
+		urls.append(url)
+	return urls
 
 
 def isSupportedUrl(url: str) -> bool:
 	"""Return whether the entire string is a supported URL."""
-	return _URL_PATTERN.fullmatch(url) is not None
-
-
-def _runConfidenceCheck() -> None:
-	"""Run a small confidence check for URL matching."""
-	assert findUrls("wwwXexample.com") == []
-	assert findUrls("http://a\nnext") == ["http://a"]
-	assert findUrls("HTML https://example.com</a>") == ["https://example.com"]
-	assert findUrls("HTTPS://example.com WWW.example.com") == [
-		"HTTPS://example.com",
-		"WWW.example.com",
-	]
-	assert findUrls("https://example.com?") == ["https://example.com?"]
-	unicodeUrl = "https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84"
-	assert findUrls(unicodeUrl) == [unicodeUrl]
-	assert isSupportedUrl("https://example.com")
-	assert not isSupportedUrl("http://")
-	assert not isSupportedUrl("https://example.com</a>")
-
-
-if __name__ == "__main__":
-	_runConfidenceCheck()
+	if _URL_PATTERN.fullmatch(url) is None or _INVALID_PERCENT_ESCAPE_PATTERN.search(url):
+		return False
+	urlToParse = f"http://{url}" if url[:4].casefold() == "www." else url
+	try:
+		parsedUrl = urlsplit(urlToParse)
+		hostname = parsedUrl.hostname
+		port = parsedUrl.port
+	except ValueError:
+		return False
+	return bool(hostname) and (port is None or 0 <= port <= 65535)

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -1,0 +1,43 @@
+"""Utilities for matching URLs supported by Open Link With."""
+
+import re
+
+
+_BAD_URL_END_CHARACTERS = "'\\.,[](){}:;\""
+_URL_PATTERN = re.compile(
+	r'(?:https?://|ftp://|www\.)[^ ,.?!#%=+<>"\\][^\s<>"\\]*',
+	re.IGNORECASE,
+)
+
+
+def findUrls(text: str) -> list[str]:
+	"""Return unique supported URLs found in text, preserving their order."""
+	return list(
+		dict.fromkeys(match.group(0).strip(_BAD_URL_END_CHARACTERS) for match in _URL_PATTERN.finditer(text))
+	)
+
+
+def isSupportedUrl(url: str) -> bool:
+	"""Return whether the entire string is a supported URL."""
+	return _URL_PATTERN.fullmatch(url) is not None
+
+
+def _runConfidenceCheck() -> None:
+	"""Run a small confidence check for URL matching."""
+	assert findUrls("wwwXexample.com") == []
+	assert findUrls("http://a\nnext") == ["http://a"]
+	assert findUrls("HTML https://example.com</a>") == ["https://example.com"]
+	assert findUrls("HTTPS://example.com WWW.example.com") == [
+		"HTTPS://example.com",
+		"WWW.example.com",
+	]
+	assert findUrls("https://example.com?") == ["https://example.com?"]
+	unicodeUrl = "https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84"
+	assert findUrls(unicodeUrl) == [unicodeUrl]
+	assert isSupportedUrl("https://example.com")
+	assert not isSupportedUrl("http://")
+	assert not isSupportedUrl("https://example.com</a>")
+
+
+if __name__ == "__main__":
+	_runConfidenceCheck()

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -65,11 +65,14 @@ def isSupportedUrl(url: str) -> bool:
 	"""Return whether the entire string is a supported URL."""
 	if _URL_PATTERN.fullmatch(url) is None or _INVALID_PERCENT_ESCAPE_PATTERN.search(url):
 		return False
-	urlToParse = f"http://{url}" if url[:4].casefold() == "www." else url
+	hasBareWwwPrefix = url[:4].casefold() == "www."
+	urlToParse = f"http://{url}" if hasBareWwwPrefix else url
 	try:
 		parsedUrl = urlsplit(urlToParse)
 		hostname = parsedUrl.hostname
 		port = parsedUrl.port
 	except ValueError:
 		return False
-	return bool(hostname) and (port is None or 0 <= port <= 65535)
+	if not hostname or (hasBareWwwPrefix and hostname.rstrip(".").casefold() == "www"):
+		return False
+	return port is None or 0 <= port <= 65535

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv6Address
 import re
 import unicodedata
 from urllib.parse import urlsplit
@@ -16,6 +17,7 @@ _URL_TERMINATOR_CHARACTER_CLASS = (
 _URL_TERMINATOR_PATTERN = re.compile(rf"[{_URL_TERMINATOR_CHARACTER_CLASS}]")
 _AUTHORITY_END_PATTERN = re.compile(rf"[/?#{_URL_TERMINATOR_CHARACTER_CLASS}]")
 _INVALID_PERCENT_ESCAPE_PATTERN = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_IPV_FUTURE_PATTERN = re.compile(r"v[0-9A-Fa-f]+\.[-A-Za-z0-9._~!$&'()*+,;=:]+")
 _HOSTNAME_PUNCTUATION_CHARACTERS = frozenset(
 	".-_%\u00b7\u0375\u05f3\u05f4\u200c\u200d\u3002\u30fb\uff0d\uff0e\uff3f\uff61"
 )
@@ -79,15 +81,42 @@ def _isAllowedUserinfoCharacter(character: str) -> bool:
 	return character.isalnum() or character in _ASCII_USERINFO_CHARACTERS
 
 
-def _findAuthorityEnd(text: str, prefixEnd: int) -> int:
+def _isValidIpLiteral(hostname: str) -> bool:
+	"""Return whether a bracketed hostname is a valid IPv6 or IPvFuture literal."""
+	if _IPV_FUTURE_PATTERN.fullmatch(hostname) is not None:
+		return True
+	ipv6Address, zoneSeparator, zoneId = hostname.partition("%25")
+	if "%" in ipv6Address or (zoneSeparator and (not zoneId or "%" in zoneId)):
+		return False
+	try:
+		_ = IPv6Address(ipv6Address)
+	except ValueError:
+		return False
+	return True
+
+
+def _findAuthorityEnd(text: str, urlStart: int, prefixEnd: int) -> int:
 	"""Return the position where a URL authority ends."""
+	if text[urlStart:prefixEnd].casefold() == "www.":
+		hasPortSeparator = False
+		for index in range(prefixEnd, len(text)):
+			character = text[index]
+			if character == ":" and not hasPortSeparator:
+				hasPortSeparator = True
+			elif _AUTHORITY_END_PATTERN.fullmatch(character) is not None or not _isAllowedHostnameCharacter(
+				character
+			):
+				return index
+		return len(text)
 	match = _AUTHORITY_END_PATTERN.search(text, prefixEnd)
 	return match.start() if match is not None else len(text)
 
 
 def _findAuthorityBoundary(text: str, urlStart: int, prefixEnd: int, authorityEnd: int) -> int:
 	"""Return the first prose boundary within a URL authority."""
-	authorityStart = urlStart if text[urlStart:prefixEnd].casefold() == "www." else prefixEnd
+	if text[urlStart:prefixEnd].casefold() == "www.":
+		return authorityEnd
+	authorityStart = prefixEnd
 	userinfoEnd = text.rfind("@", authorityStart, authorityEnd)
 	if userinfoEnd >= 0:
 		for index in range(authorityStart, userinfoEnd):
@@ -120,7 +149,7 @@ def _findAuthorityBoundary(text: str, urlStart: int, prefixEnd: int, authorityEn
 
 def _findUrlCandidateEnd(text: str, urlStart: int, prefixEnd: int) -> int:
 	"""Return the end of one URL candidate without scanning later candidates."""
-	authorityEnd = _findAuthorityEnd(text, prefixEnd)
+	authorityEnd = _findAuthorityEnd(text, urlStart, prefixEnd)
 	authorityBoundary = _findAuthorityBoundary(text, urlStart, prefixEnd, authorityEnd)
 	if authorityBoundary < authorityEnd:
 		return authorityBoundary
@@ -211,10 +240,11 @@ def isSupportedUrl(url: str) -> bool:
 	prefixMatch = _URL_PREFIX_PATTERN.match(url)
 	if prefixMatch is None or not _hasValidUrlStart(url, prefixMatch.end()):
 		return False
-	authorityEnd = _findAuthorityEnd(url, prefixMatch.end())
+	authorityEnd = _findAuthorityEnd(url, 0, prefixMatch.end())
 	if (
 		_URL_TERMINATOR_PATTERN.search(url) is not None
 		or _INVALID_PERCENT_ESCAPE_PATTERN.search(url)
+		or (authorityEnd < len(url) and url[authorityEnd] not in "/?#")
 		or _findAuthorityBoundary(url, 0, prefixMatch.end(), authorityEnd) != authorityEnd
 	):
 		return False
@@ -227,5 +257,8 @@ def isSupportedUrl(url: str) -> bool:
 	except ValueError:
 		return False
 	if not hostname or (hasBareWwwPrefix and hostname.rstrip(".").casefold() == "www"):
+		return False
+	hostAndPort = parsedUrl.netloc.rsplit("@", 1)[-1]
+	if hostAndPort.startswith("[") and not _isValidIpLiteral(hostAndPort[1:].partition("]")[0]):
 		return False
 	return port is None or 0 <= port <= 65535

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -3,20 +3,176 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from urllib.parse import urlsplit
 
 
-_URL_TERMINATOR_PATTERN = r'\s\x00-\x1f\x7f-\x9f<>"\\^`{|}'
-_URL_PATTERN = re.compile(
-	rf"(?:https?://|ftp://|www\.)"
-	rf"[^,.?!#%=+{_URL_TERMINATOR_PATTERN}]"
-	rf"[^{_URL_TERMINATOR_PATTERN}]*",
-	re.IGNORECASE,
+_URL_PREFIX_PATTERN = re.compile(r"(?:https?://|ftp://|www\.)", re.IGNORECASE)
+_INVALID_INITIAL_URL_CHARACTERS = frozenset(",.?!#%=+")
+_URL_TERMINATOR_PATTERN = re.compile(
+	r'[\s\x00-\x1f\x7f-\x9f<>"\\^`{|}'
+	r"\u061c\u200b\u200e-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u206f\ufeff\uff5c]"
 )
 _INVALID_PERCENT_ESCAPE_PATTERN = re.compile(r"%(?![0-9A-Fa-f]{2})")
-_UNCONDITIONAL_TRAILING_CHARACTERS = "'.,[(:;"
-_CLOSING_TO_OPENING_DELIMITERS = {")": "(", "]": "["}
-_TRIMMABLE_TRAILING_CHARACTERS = _UNCONDITIONAL_TRAILING_CHARACTERS + "".join(_CLOSING_TO_OPENING_DELIMITERS)
+_HOSTNAME_PUNCTUATION_CHARACTERS = frozenset(
+	".-_%\u00b7\u0375\u05f3\u05f4\u200c\u200d\u3002\u30fb\uff0d\uff0e\uff3f\uff61"
+)
+_ASCII_USERINFO_CHARACTERS = frozenset("-._~%!$&'()*+,;=:@")
+_UNCONDITIONAL_TRAILING_CHARACTERS = (
+	"'.,:;"
+	"\u055d\u055e\u0589\u05c3\u060c\u061b\u061f\u06d4"
+	"\u0964\u0965\u0f0d\u0f0e\u104a\u104b\u1362\u1367"
+	"\u3001\u3002\uff01\uff0c\uff0e\uff1a\uff1b\uff1f\uff61"
+)
+_CLOSING_TO_OPENING_DELIMITERS = {
+	")": "(",
+	"]": "[",
+	"\u00bb": "\u00ab",
+	"\u2019": "\u2018",
+	"\u201d": "\u201c",
+	"\u203a": "\u2039",
+	"\u3009": "\u3008",
+	"\u300b": "\u300a",
+	"\u300d": "\u300c",
+	"\u300f": "\u300e",
+	"\u3011": "\u3010",
+	"\u3015": "\u3014",
+	"\u3017": "\u3016",
+	"\u3019": "\u3018",
+	"\u301b": "\u301a",
+	"\uff63": "\uff62",
+	"\uff09": "\uff08",
+	"\uff3d": "\uff3b",
+	"\uff5d": "\uff5b",
+}
+_OPENING_TO_CLOSING_DELIMITERS = {
+	opening: closing for closing, opening in _CLOSING_TO_OPENING_DELIMITERS.items()
+}
+_TRIMMABLE_TRAILING_CHARACTERS = (
+	_UNCONDITIONAL_TRAILING_CHARACTERS
+	+ "".join(_CLOSING_TO_OPENING_DELIMITERS)
+	+ "".join(_CLOSING_TO_OPENING_DELIMITERS.values())
+)
+
+
+def _isUrlTerminator(character: str) -> bool:
+	"""Return whether a character definitely ends a raw URL candidate."""
+	return _URL_TERMINATOR_PATTERN.fullmatch(character) is not None
+
+
+def _hasValidUrlStart(text: str, prefixEnd: int) -> bool:
+	"""Return whether a supported prefix is followed by a possible URL character."""
+	return (
+		prefixEnd < len(text)
+		and text[prefixEnd] not in _INVALID_INITIAL_URL_CHARACTERS
+		and not _isUrlTerminator(text[prefixEnd])
+	)
+
+
+def _isAllowedHostnameCharacter(character: str) -> bool:
+	"""Return whether a raw character can be part of a browser-facing hostname."""
+	if character in _HOSTNAME_PUNCTUATION_CHARACTERS:
+		return True
+	# cmark-gfm and linkify-it admit Unicode symbols as well as letters, marks, and numbers.
+	return unicodedata.category(character)[0] in "LMNS"
+
+
+def _isAllowedUserinfoCharacter(character: str) -> bool:
+	"""Return whether a raw character can occur before an authority's final at sign."""
+	if not character.isascii():
+		return not _isUrlTerminator(character)
+	return character.isalnum() or character in _ASCII_USERINFO_CHARACTERS
+
+
+def _truncateAtAuthorityBoundary(url: str) -> str:
+	"""Stop a URL candidate at prose punctuation in its hostname or port."""
+	authorityStart = 0 if url[:4].casefold() == "www." else url.find("://") + 3
+	authorityEnd = len(url)
+	for separator in "/?#":
+		separatorIndex = url.find(separator, authorityStart)
+		if separatorIndex >= 0:
+			authorityEnd = min(authorityEnd, separatorIndex)
+	userinfoEnd = url.rfind("@", authorityStart, authorityEnd)
+	if userinfoEnd >= 0:
+		for index in range(authorityStart, userinfoEnd):
+			if not _isAllowedUserinfoCharacter(url[index]):
+				return url[:index]
+	hostnameStart = userinfoEnd + 1 if userinfoEnd >= 0 else authorityStart
+	if hostnameStart >= authorityEnd:
+		return url
+
+	if url[hostnameStart] == "[":
+		closingBracket = url.find("]", hostnameStart + 1, authorityEnd)
+		if closingBracket < 0:
+			return url
+		hostnameEnd = closingBracket + 1
+	else:
+		portSeparator = url.find(":", hostnameStart, authorityEnd)
+		hostnameEnd = portSeparator if portSeparator >= 0 else authorityEnd
+		for index in range(hostnameStart, hostnameEnd):
+			if not _isAllowedHostnameCharacter(url[index]):
+				return url[:index]
+
+	if hostnameEnd >= authorityEnd:
+		return url
+	portStart = hostnameEnd + 1 if url[hostnameEnd] == ":" else hostnameEnd
+	for index in range(portStart, authorityEnd):
+		if not _isAllowedHostnameCharacter(url[index]):
+			return url[:index]
+	return url
+
+
+def _findUrlCandidateEnd(text: str, urlStart: int, prefixEnd: int) -> int:
+	"""Return the end of one URL candidate without scanning later candidates."""
+	authorityEnd = len(text)
+	for separator in "/?#":
+		separatorIndex = text.find(separator, prefixEnd)
+		if separatorIndex >= 0:
+			authorityEnd = min(authorityEnd, separatorIndex)
+	terminatorMatch = _URL_TERMINATOR_PATTERN.search(text, prefixEnd, authorityEnd)
+	if terminatorMatch is not None:
+		authorityEnd = terminatorMatch.start()
+
+	authorityCandidate = text[urlStart:authorityEnd]
+	truncatedAuthority = _truncateAtAuthorityBoundary(authorityCandidate)
+	if len(truncatedAuthority) < len(authorityCandidate):
+		return urlStart + len(truncatedAuthority)
+	if authorityEnd >= len(text) or _isUrlTerminator(text[authorityEnd]):
+		return authorityEnd
+
+	precedingCharacter = text[urlStart - 1] if urlStart else ""
+	closing = _OPENING_TO_CLOSING_DELIMITERS.get(precedingCharacter)
+	if precedingCharacter == "'":
+		closingIndex = text.find("'", authorityEnd)
+		searchEnd = closingIndex if closingIndex >= 0 else len(text)
+		terminatorMatch = _URL_TERMINATOR_PATTERN.search(text, authorityEnd, searchEnd)
+		return terminatorMatch.start() if terminatorMatch is not None else searchEnd
+	if closing is None:
+		terminatorMatch = _URL_TERMINATOR_PATTERN.search(text, authorityEnd)
+		return terminatorMatch.start() if terminatorMatch is not None else len(text)
+
+	delimiterDepth = 1
+	searchStart = authorityEnd
+	while searchStart < len(text):
+		nextOpening = text.find(precedingCharacter, searchStart)
+		nextClosing = text.find(closing, searchStart)
+		nextDelimiter = min(
+			(index for index in (nextOpening, nextClosing) if index >= 0),
+			default=len(text),
+		)
+		terminatorMatch = _URL_TERMINATOR_PATTERN.search(text, searchStart, nextDelimiter)
+		if terminatorMatch is not None:
+			return terminatorMatch.start()
+		if nextDelimiter >= len(text):
+			return len(text)
+		if nextDelimiter == nextOpening:
+			delimiterDepth += 1
+		else:
+			delimiterDepth -= 1
+			if delimiterDepth == 0:
+				return nextDelimiter
+		searchStart = nextDelimiter + 1
+	return len(text)
 
 
 def _trimUrlEnd(url: str) -> str:
@@ -24,6 +180,8 @@ def _trimUrlEnd(url: str) -> str:
 	suffixStart = len(url)
 	while suffixStart and url[suffixStart - 1] in _TRIMMABLE_TRAILING_CHARACTERS:
 		suffixStart -= 1
+	if suffixStart == len(url):
+		return url
 
 	delimiterBalance = {opening: 0 for opening in _CLOSING_TO_OPENING_DELIMITERS.values()}
 	for index in range(suffixStart):
@@ -52,8 +210,17 @@ def findUrls(text: str) -> list[str]:
 	"""Return unique supported URLs found in text, preserving their order."""
 	urls: list[str] = []
 	seenUrls: set[str] = set()
-	for match in _URL_PATTERN.finditer(text):
-		url = _trimUrlEnd(match.group(0))
+	searchStart = 0
+	while True:
+		prefixMatch = _URL_PREFIX_PATTERN.search(text, searchStart)
+		if prefixMatch is None:
+			break
+		if not _hasValidUrlStart(text, prefixMatch.end()):
+			searchStart = prefixMatch.end()
+			continue
+		candidateEnd = _findUrlCandidateEnd(text, prefixMatch.start(), prefixMatch.end())
+		url = _trimUrlEnd(text[prefixMatch.start() : candidateEnd])
+		searchStart = max(candidateEnd, prefixMatch.end())
 		if url in seenUrls or not isSupportedUrl(url):
 			continue
 		seenUrls.add(url)
@@ -63,7 +230,14 @@ def findUrls(text: str) -> list[str]:
 
 def isSupportedUrl(url: str) -> bool:
 	"""Return whether the entire string is a supported URL."""
-	if _URL_PATTERN.fullmatch(url) is None or _INVALID_PERCENT_ESCAPE_PATTERN.search(url):
+	prefixMatch = _URL_PREFIX_PATTERN.match(url)
+	if (
+		prefixMatch is None
+		or not _hasValidUrlStart(url, prefixMatch.end())
+		or _URL_TERMINATOR_PATTERN.search(url) is not None
+		or _INVALID_PERCENT_ESCAPE_PATTERN.search(url)
+		or _truncateAtAuthorityBoundary(url) != url
+	):
 		return False
 	hasBareWwwPrefix = url[:4].casefold() == "www."
 	urlToParse = f"http://{url}" if hasBareWwwPrefix else url

--- a/addon/globalPlugins/openLinkWith/urlUtils.py
+++ b/addon/globalPlugins/openLinkWith/urlUtils.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from ipaddress import IPv6Address
 import re
+from socket import AF_INET6, inet_pton
 import unicodedata
 from urllib.parse import urlsplit
 
@@ -89,8 +89,8 @@ def _isValidIpLiteral(hostname: str) -> bool:
 	if "%" in ipv6Address or (zoneSeparator and (not zoneId or "%" in zoneId)):
 		return False
 	try:
-		_ = IPv6Address(ipv6Address)
-	except ValueError:
+		_ = inet_pton(AF_INET6, ipv6Address)
+	except OSError:
 		return False
 	return True
 

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -5,14 +5,19 @@ from collections.abc import Callable
 from itertools import product
 from pathlib import Path
 import runpy
+from types import FunctionType
 from typing import cast
 import unittest
+from unittest.mock import Mock, patch
+from urllib.parse import SplitResult
 
 
 _URL_UTILS_PATH = Path(__file__).parents[2] / "addon" / "globalPlugins" / "openLinkWith" / "urlUtils.py"
 _URL_UTILS_NAMESPACE = runpy.run_path(str(_URL_UTILS_PATH))
 _findUrls = cast(Callable[[str], list[str]], _URL_UTILS_NAMESPACE["findUrls"])
+_isValidIpLiteral = cast(Callable[[str], bool], _URL_UTILS_NAMESPACE["_isValidIpLiteral"])
 _isSupportedUrl = cast(Callable[[str], bool], _URL_UTILS_NAMESPACE["isSupportedUrl"])
+_IS_SUPPORTED_URL_GLOBALS = cast(FunctionType, _URL_UTILS_NAMESPACE["isSupportedUrl"]).__globals__
 
 
 class FindUrlsTests(unittest.TestCase):
@@ -228,6 +233,11 @@ class FindUrlsTests(unittest.TestCase):
 		adjacentUrls = [f"http://host{index}" for index in range(1000)]
 		self.assertEqual(adjacentUrls, _findUrls(",".join(adjacentUrls)))
 
+	def testHandlesManyAdjacentBareWwwUrls(self) -> None:
+		"""Do not rescan the remaining text for every comma-separated bare URL."""
+		adjacentUrls = [f"www.host{index}" for index in range(4000)]
+		self.assertEqual(adjacentUrls, _findUrls(",".join(adjacentUrls)))
+
 
 class EstablishedAutolinkerRegressionTests(unittest.TestCase):
 	"""Regression cases adapted to this add-on from established URL autolinkers."""
@@ -339,6 +349,8 @@ class SupportedUrlTests(unittest.TestCase):
 			"WWW.example.com/path?q=1#fragment",
 			"ftp://user:pass@example.com:21/a%20b",
 			"http://[::1]",
+			"http://[2001:db8::1]",
+			"http://[::ffff:192.0.2.1]",
 			"http://[v1.a]",
 			"http://[fe80::1%25eth0]/",
 			"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
@@ -441,6 +453,38 @@ class SupportedUrlTests(unittest.TestCase):
 			with self.subTest(port=port):
 				self.assertFalse(_isSupportedUrl(url))
 
+	def testValidatesIpLiteralsIndependentlyOfUrlsplit(self) -> None:
+		"""Apply stable IPv6 and IPvFuture validation across supported Python versions."""
+		validLiterals = (
+			"::1",
+			"2001:db8::1",
+			"::ffff:192.0.2.1",
+			"v1.a",
+			"vF.a-._~!$&'()*+,;=:",
+			"fe80::1%25eth0",
+		)
+		for literal in validLiterals:
+			with self.subTest(literal=literal):
+				self.assertTrue(_isValidIpLiteral(literal))
+
+		invalidLiterals = (
+			":::",
+			"gggg::1",
+			"127.0.0.1",
+			"v.a",
+			"V1.a",
+			"v1.",
+			"::1%25",
+			"fe80::1%20eth0",
+			"fe80::1%25eth%25zero",
+		)
+		for literal in invalidLiterals:
+			with self.subTest(literal=literal):
+				self.assertFalse(_isValidIpLiteral(literal))
+				legacyResult = SplitResult("http", f"[{literal}]", "", "", "")
+				with patch.dict(_IS_SUPPORTED_URL_GLOBALS, {"urlsplit": Mock(return_value=legacyResult)}):
+					self.assertFalse(_isSupportedUrl(f"http://[{literal}]"))
+
 	def testRejectsInvalidUrls(self) -> None:
 		"""Reject URLs with missing hosts, invalid ports, escapes, or raw delimiters."""
 		invalidUrls = (
@@ -454,6 +498,9 @@ class SupportedUrlTests(unittest.TestCase):
 			"http://[:::]",
 			"http://[gggg::1]",
 			"http://[v.a]",
+			"http://[127.0.0.1]",
+			"http://[v1.]",
+			"http://[::1%25]",
 			"http://::1",
 			"http://example.com:abc",
 			"http://example.com:65536",
@@ -490,6 +537,7 @@ class SupportedUrlTests(unittest.TestCase):
 			"https://?query",
 			"https://#fragment",
 			"www./path",
+			"www.example.com,tail",
 			"http://example.com\uff0fpath",
 			"http://example.com\uff1a80",
 		)

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -725,6 +725,12 @@ class InternationalUrlTests(unittest.TestCase):
 class SourceCompatibilityTests(unittest.TestCase):
 	"""Tests for compatibility with the add-on's declared minimum NVDA version."""
 
+	def testLoadsWithoutUnbundledIpaddressModule(self) -> None:
+		"""Load when ipaddress is absent from NVDA's frozen standard library."""
+		with patch.dict("sys.modules", {"ipaddress": None}):
+			namespace = runpy.run_path(str(_URL_UTILS_PATH))
+		self.assertIn("findUrls", namespace)
+
 	def testSupportsPython37Grammar(self) -> None:
 		"""Keep production code parseable by the Python version in NVDA 2021.1."""
 		ast.parse(_URL_UTILS_PATH.read_text(encoding="utf-8"), feature_version=(3, 7))

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -1,0 +1,136 @@
+"""Unit tests for Open Link With URL matching utilities."""
+
+import ast
+from collections.abc import Callable
+from pathlib import Path
+import runpy
+from typing import cast
+import unittest
+
+
+_URL_UTILS_PATH = Path(__file__).parents[2] / "addon" / "globalPlugins" / "openLinkWith" / "urlUtils.py"
+_URL_UTILS_NAMESPACE = runpy.run_path(str(_URL_UTILS_PATH))
+_findUrls = cast(Callable[[str], list[str]], _URL_UTILS_NAMESPACE["findUrls"])
+_isSupportedUrl = cast(Callable[[str], bool], _URL_UTILS_NAMESPACE["isSupportedUrl"])
+
+
+class FindUrlsTests(unittest.TestCase):
+	"""Tests for extracting supported URLs from text."""
+
+	def testDefiniteTerminators(self) -> None:
+		"""Stop at characters which cannot occur raw in a URI or IRI."""
+		cases = (
+			("http://\nnext", []),
+			("http://\tnext", []),
+			('http://a\nnext"', ["http://a"]),
+			("https://example.com\x00suffix", ["https://example.com"]),
+			("https://example.com^suffix", ["https://example.com"]),
+			("https://example.com`suffix", ["https://example.com"]),
+			("https://example.com{suffix", ["https://example.com"]),
+			("https://example.com|suffix", ["https://example.com"]),
+			("https://example.com}suffix", ["https://example.com"]),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual(expected, _findUrls(text))
+
+	def testBalancedDelimiters(self) -> None:
+		"""Preserve balanced URL delimiters and trim surrounding prose delimiters."""
+		cases = (
+			("http://[::1]", ["http://[::1]"]),
+			(
+				"https://en.wikipedia.org/wiki/Function_(mathematics)",
+				["https://en.wikipedia.org/wiki/Function_(mathematics)"],
+			),
+			("(https://example.com)", ["https://example.com"]),
+			("(https://example.com/a(b))", ["https://example.com/a(b)"]),
+			("https://example.com/a(b)))", ["https://example.com/a(b)"]),
+			("[http://[::1]]", ["http://[::1]"]),
+			("https://example.com/][]", ["https://example.com/][]"]),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual(expected, _findUrls(text))
+
+	def testRejectsInvalidCandidates(self) -> None:
+		"""Discard extracted candidates which are not usable URLs."""
+		invalidUrls = (
+			"http://:",
+			"http:///path",
+			"http://user@",
+			"http://example.com:abc",
+			"http://example.com:70000",
+			"https://example.com/%ZZ",
+		)
+		for url in invalidUrls:
+			with self.subTest(url=url):
+				self.assertEqual([], _findUrls(url))
+
+	def testPreservesExistingBehavior(self) -> None:
+		"""Preserve case, Unicode, ordering, deduplication, and valid URL punctuation."""
+		unicodeUrl = "https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84"
+		text = f"HTTPS://example.com {unicodeUrl} https://example.com? HTTPS://example.com"
+		self.assertEqual(
+			["HTTPS://example.com", unicodeUrl, "https://example.com?"],
+			_findUrls(text),
+		)
+		self.assertEqual([], _findUrls("wwwXexample.com"))
+		self.assertEqual(["https://example.com"], _findUrls("HTML https://example.com</a>"))
+		self.assertEqual(
+			["http://a", "https://example.com"],
+			_findUrls("http://a\nhttps://example.com"),
+		)
+
+
+class SupportedUrlTests(unittest.TestCase):
+	"""Tests for validating complete supported URLs."""
+
+	def testAcceptsValidUrls(self) -> None:
+		"""Accept representative valid URLs for every supported form."""
+		validUrls = (
+			"https://example.com",
+			"HTTPS://example.com?",
+			"WWW.example.com/path?q=1#fragment",
+			"ftp://user:pass@example.com:21/a%20b",
+			"http://[::1]",
+			"http://[v1.a]",
+			"http://[fe80::1%25eth0]/",
+			"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			"http://example.com:65535/path",
+		)
+		for url in validUrls:
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+
+	def testRejectsInvalidUrls(self) -> None:
+		"""Reject URLs with missing hosts, invalid ports, escapes, or raw delimiters."""
+		invalidUrls = (
+			"http://",
+			"www.",
+			"http://:",
+			"http:///path",
+			"http://user@",
+			"http://[::1",
+			"http://[]",
+			"http://example.com:abc",
+			"http://example.com:65536",
+			"https://example.com/%",
+			"https://example.com/%0",
+			"https://example.com/%GG",
+			"https://example.com^suffix",
+		)
+		for url in invalidUrls:
+			with self.subTest(url=url):
+				self.assertFalse(_isSupportedUrl(url))
+
+
+class SourceCompatibilityTests(unittest.TestCase):
+	"""Tests for compatibility with the add-on's declared minimum NVDA version."""
+
+	def testSupportsPython37Grammar(self) -> None:
+		"""Keep production code parseable by the Python version in NVDA 2021.1."""
+		ast.parse(_URL_UTILS_PATH.read_text(encoding="utf-8"), feature_version=(3, 7))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -54,6 +54,25 @@ class FindUrlsTests(unittest.TestCase):
 					_findUrls(f"https://example.com{character}suffix"),
 				)
 
+	def testUnicodeDisplayControlsTerminateCandidates(self) -> None:
+		"""Stop at invisible display controls and the fullwidth text separator."""
+		terminators = (
+			"\u061c",
+			"\u200b",
+			"\u200e",
+			"\u200f",
+			*(chr(value) for value in range(0x202A, 0x202F)),
+			*(chr(value) for value in range(0x2060, 0x2065)),
+			*(chr(value) for value in range(0x2066, 0x2070)),
+			"\ufeff",
+			"\uff5c",
+		)
+		for character in terminators:
+			text = f"https://example.com{character}suffix"
+			with self.subTest(codePoint=f"U+{ord(character):04X}"):
+				self.assertEqual(["https://example.com"], _findUrls(text))
+				self.assertFalse(_isSupportedUrl(text))
+
 	def testBalancedDelimiters(self) -> None:
 		"""Preserve balanced URL delimiters and trim surrounding prose delimiters."""
 		cases = (
@@ -102,6 +121,34 @@ class FindUrlsTests(unittest.TestCase):
 			('{"url": "https://example.com/a"}', ["https://example.com/a"]),
 			("https://one.example^https://two.example", ["https://one.example", "https://two.example"]),
 			("https://one.example\\https://two.example", ["https://one.example", "https://two.example"]),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual(expected, _findUrls(text))
+
+	def testKeepsScanningAfterAnInlineBoundary(self) -> None:
+		"""Find a following URL when punctuation or an outer wrapper ends the previous URL."""
+		cases = (
+			(
+				"http://one.example,http://two.example",
+				["http://one.example", "http://two.example"],
+			),
+			(
+				"https://one.example\uff0chttps://two.example",
+				["https://one.example", "https://two.example"],
+			),
+			(
+				"(http://one.example/path)https://two.example/path",
+				["http://one.example/path", "https://two.example/path"],
+			),
+			(
+				"\u300ahttps://one.example/\u8def\u5f84\u300bhttps://two.example/\u8def\u5f84",
+				["https://one.example/\u8def\u5f84", "https://two.example/\u8def\u5f84"],
+			),
+			(
+				"http://example.com:invalid,https://valid.example",
+				["https://valid.example"],
+			),
 		)
 		for text, expected in cases:
 			with self.subTest(text=text):
@@ -168,6 +215,116 @@ class FindUrlsTests(unittest.TestCase):
 		balancedUrl = "https://example.com/" + ("(" * 512) + "a" + (")" * 512)
 		self.assertEqual([balancedUrl], _findUrls(balancedUrl))
 		self.assertEqual([], _findUrls("http:/" * 10000))
+
+	def testHandlesLongUnicodeAndWrapperInputs(self) -> None:
+		"""Keep Unicode hostname and wrapper scans linear on pathological input sizes."""
+		unicodeUrl = "https://" + ("\ud55c.\uae00." * 10000) + "example"
+		self.assertEqual([unicodeUrl], _findUrls(unicodeUrl))
+		self.assertEqual(
+			["https://example.com/path"],
+			_findUrls(("(" * 10000) + "https://example.com/path" + (")" * 10000)),
+		)
+		adjacentUrls = [f"http://host{index}" for index in range(1000)]
+		self.assertEqual(adjacentUrls, _findUrls(",".join(adjacentUrls)))
+
+
+class EstablishedAutolinkerRegressionTests(unittest.TestCase):
+	"""Regression cases adapted to this add-on from established URL autolinkers."""
+
+	def testCmarkGfmTrailingPunctuationAndParentheses(self) -> None:
+		"""Retain cmark-gfm URL punctuation and balanced-parenthesis behavior."""
+		cases = (
+			("(Scoped http://example.com/foo_bar)", "http://example.com/foo_bar"),
+			("http://example.com/foo_bar...", "http://example.com/foo_bar"),
+			(
+				"www.google.com/search?q=Markup+(business)))",
+				"www.google.com/search?q=Markup+(business)",
+			),
+			(
+				"http://index-of.es/Android/Professional.Android.2.Application.Development.(Wrox,.2010).pdf",
+				"http://index-of.es/Android/Professional.Android.2.Application.Development.(Wrox,.2010).pdf",
+			),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual([expected], _findUrls(text))
+
+	def testLinkifyItAuthorityAndTextSeparators(self) -> None:
+		"""Stop at linkify-it-style host punctuation and fullwidth vertical bars."""
+		cases = (
+			("http://example.com,next", "http://example.com"),
+			("http://example.com:8080,next", "http://example.com:8080"),
+			("https://example.com\uff0c\u540e\u6587", "https://example.com"),
+			("\uff5chttp://google.com\uff5cbar", "http://google.com"),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual([expected], _findUrls(text))
+				self.assertFalse(_isSupportedUrl(text))
+
+	def testLinkifyItMarkdownDestinationsDoNotMerge(self) -> None:
+		"""Do not treat an at sign in a later Markdown destination as URL userinfo."""
+		text = "[https](https://www.ibm.com)[mailto](mailto:someone@ibm.com)"
+		self.assertEqual(["https://www.ibm.com"], _findUrls(text))
+
+	def testOuterWrappersEndBeforeAdjacentText(self) -> None:
+		"""End at a URL's outer wrapper even when prose follows without whitespace."""
+		cases = (
+			("(http://example.com/path)next", "http://example.com/path"),
+			("[http://example.com/path]next", "http://example.com/path"),
+			("'http://example.com/path'next", "http://example.com/path"),
+			(
+				"\u300ahttps://example.com/\u300a\u5185\u5c42\u300bpage\u300b\u540e\u6587",
+				"https://example.com/\u300a\u5185\u5c42\u300bpage",
+			),
+			("\u201chttps://example.com/\u8def\u5f84\u201d\u540e\u6587", "https://example.com/\u8def\u5f84"),
+			("\uff08https://example.com/\u8def\u5f84\uff09\u540e\u6587", "https://example.com/\u8def\u5f84"),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual([expected], _findUrls(text))
+
+	def testVsCodeInternationalPathCases(self) -> None:
+		"""Preserve CJK path characters covered by VS Code's LinkComputer regressions."""
+		cases = (
+			(
+				"\u8bf7\u53c2\u9605 http://go.microsoft.com/fwlink/?LinkId=761051\u3002",
+				"http://go.microsoft.com/fwlink/?LinkId=761051",
+			),
+			(
+				"https://zh.wikipedia.org/wiki/\u3010\u6211\u63a8\u7684\u5b69\u5b50\u3011",
+				"https://zh.wikipedia.org/wiki/\u3010\u6211\u63a8\u7684\u5b69\u5b50\u3011",
+			),
+			(
+				"https://zh.wikipedia.org/wiki/\u300a\u65b0\u9752\u5e74\u300b\u7f16\u8f91\u90e8\u65e7\u5740",
+				"https://zh.wikipedia.org/wiki/\u300a\u65b0\u9752\u5e74\u300b\u7f16\u8f91\u90e8\u65e7\u5740",
+			),
+			(
+				"https://zh.wikipedia.org/wiki/\u201c\u5e38\u51ef\u7533\u201d\u8bef\u8bd1\u4e8b\u4ef6",
+				"https://zh.wikipedia.org/wiki/\u201c\u5e38\u51ef\u7533\u201d\u8bef\u8bd1\u4e8b\u4ef6",
+			),
+			(
+				"http://tree-mark.chips.jp/\u30ec\u30fc\u30ba\u30f3\uff06\u30d9\u30ea\u30fc\u30df\u30c3\u30af\u30b9",
+				"http://tree-mark.chips.jp/\u30ec\u30fc\u30ba\u30f3\uff06\u30d9\u30ea\u30fc\u30df\u30c3\u30af\u30b9",
+			),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual([expected], _findUrls(text))
+
+	def testDjangoAndLinkifyInternationalHosts(self) -> None:
+		"""Leave browser-facing IDNA policy to the user agent, as Django and linkify-it do."""
+		validUrls = (
+			"http://\U0001f453.ws",
+			"http://\u272adf.ws/123",
+			"https://example\U0001f600.com/path",
+			"https://\u0789\u07a8\u0780\u07a7\u0783\u07aa.com",
+			"https://www.\u0646\u0627\u0645\u0647\u200c\u0627\u06cc.com",
+		)
+		for url in validUrls:
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
 
 
 class SupportedUrlTests(unittest.TestCase):
@@ -273,6 +430,169 @@ class SupportedUrlTests(unittest.TestCase):
 		for url in invalidUrls:
 			with self.subTest(url=url):
 				self.assertFalse(_isSupportedUrl(url))
+
+
+class InternationalUrlTests(unittest.TestCase):
+	"""Tests for internationalized domain names and multilingual URL content."""
+
+	def testAcceptsInternationalHostnamesAndPaths(self) -> None:
+		"""Accept representative scripts in hostnames and paths without changing their text."""
+		validUrls = (
+			"https://m\u00fcnich.example/caf\u00e9",
+			"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			"https://\u0645\u062b\u0627\u0644.\u0625\u062e\u062a\u0628\u0627\u0631/\u0645\u0633\u0627\u0631",
+			"https://\u05d3\u05d5\u05d2\u05de\u05d4.\u05d9\u05e9\u05e8\u05d0\u05dc/\u05de\u05e1\u05dc\u05d5\u05dc",
+			"https://\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444/\u043f\u0443\u0442\u044c",
+			"https://\u03c0\u03b1\u03c1\u03ac\u03b4\u03b5\u03b9\u03b3\u03bc\u03b1.\u03b4\u03bf\u03ba\u03b9\u03bc\u03ae/\u03b4\u03b9\u03b1\u03b4\u03c1\u03bf\u03bc\u03ae",
+			"https://\u0909\u0926\u093e\u0939\u0930\u0923.\u092d\u093e\u0930\u0924/\u092e\u093e\u0930\u094d\u0917",
+			"https://\u0989\u09a6\u09be\u09b9\u09b0\u09a3.\u09ac\u09be\u0982\u09b2\u09be/\u09aa\u09a5",
+			"https://\u0e15\u0e31\u0e27\u0e2d\u0e22\u0e48\u0e32\u0e07.\u0e44\u0e17\u0e22/\u0e40\u0e2a\u0e49\u0e19\u0e17\u0e32\u0e07",
+			"https://\u4f8b\u3048.\u30c6\u30b9\u30c8/\u30d1\u30b9",
+			"https://\uc608\uc2dc.\ud14c\uc2a4\ud2b8/\uacbd\ub85c",
+			"www.\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			"ftp://\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444/\u0444\u0430\u0439\u043b",
+		)
+		for url in validUrls:
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
+
+	def testAcceptsIdnaFormsAndContextCharacters(self) -> None:
+		"""Accept IDNA dot forms, compatibility forms, and contextual join or punctuation characters."""
+		validUrls = (
+			"https://\u4f8b\u5b50\u3002\u4e2d\u56fd/path",
+			"https://\uff45\uff58\uff41\uff4d\uff50\uff4c\uff45\uff0ecom/path",
+			"https://xn--fsqu00a.xn--fiqs8s/path",
+			"https://l\u00b7l.cat/path",
+			"https://\u30c6\u30fb\u30b9\u30c8.jp/path",
+			"https://\u05d0\u05f3.co.il/path",
+			"https://cafe\u0301.example/path",
+			"https://\u0645\u062b\u0627\u0644\u200c\u0646\u0627\u0645\u0647.com/path",
+			"https://\u0915\u094d\u200d\u0937.com/path",
+			"https://\u0375\u03b1.gr/path",
+			"https://\u30fb\u30c6.jp/path",
+		)
+		for url in validUrls:
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
+
+	def testPreservesMultilingualPathQueryAndFragmentContent(self) -> None:
+		"""Preserve Unicode punctuation and symbols after the authority component."""
+		validUrls = (
+			"https://example.com/\u4f60\u597d\uff0c\u4e16\u754c",
+			"https://example.com/\u0645\u0631\u062d\u0628\u0627\u060c\u0627\u0644\u0639\u0627\u0644\u0645",
+			"https://example.com/\u0645\u0631\u062d\u0628\u0627\u061f\u0646\u0639\u0645",
+			"https://example.com/\u05e9\u05dc\u05d5\u05dd\u05be\u05e2\u05d5\u05dc\u05dd",
+			"https://example.com/emoji/\U0001f600?q=\u65e5\u672c\u8a9e#\ud55c\uad6d\uc5b4",
+			"https://example.com/cafe\u0301",
+			"https://example.com/\u0915\u094d\u200d\u0937",
+			"https://\u7528\u6237:\u5bc6\u7801@example.com/\u8d44\u6e90",
+		)
+		for url in validUrls:
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
+
+	def testStopsAtInternationalAuthorityBoundaries(self) -> None:
+		"""Stop at multilingual prose punctuation and display controls after a hostname."""
+		cases = (
+			("https://example.com\uff0c\u540e\u6587", "https://example.com"),
+			("https://example.com\u3001\u5f8c", "https://example.com"),
+			("https://example.com\u060c\u0646\u0635", "https://example.com"),
+			("https://example.com\u061f\u0646\u0635", "https://example.com"),
+			("https://example.com\u055d\u0570\u0565\u057f\u0578", "https://example.com"),
+			("https://example.com\u200bnext", "https://example.com"),
+			("https://example.com\u200f\u0646\u0635", "https://example.com"),
+			("https://example.com\u061c\u0646\u0635", "https://example.com"),
+			("https://example.com\ufeffnext", "https://example.com"),
+			("https://example.com\uff0fpath", "https://example.com"),
+			("https://example.com\uff1a8080", "https://example.com"),
+			("https://\u4f8b\u5b50.\u4e2d\u56fd\uff0c\u540e\u6587", "https://\u4f8b\u5b50.\u4e2d\u56fd"),
+			("www.\u4f8b\u5b50.\u4e2d\u56fd\u060c\u0646\u0635", "www.\u4f8b\u5b50.\u4e2d\u56fd"),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertFalse(_isSupportedUrl(text))
+				self.assertEqual([expected], _findUrls(text))
+
+	def testTrimsInternationalProseWrappers(self) -> None:
+		"""Trim multilingual sentence punctuation and wrappers while preserving balanced path content."""
+		cases = (
+			(
+				"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84\u3002",
+				"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			),
+			(
+				"https://example.com/\u0645\u0633\u0627\u0631\u061f",
+				"https://example.com/\u0645\u0633\u0627\u0631",
+			),
+			(
+				"\u300ahttps://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84\u300b",
+				"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			),
+			(
+				"\uff08https://example.com/\u8def\u5f84\uff08\u6d4b\u8bd5\uff09\uff09\u3002",
+				"https://example.com/\u8def\u5f84\uff08\u6d4b\u8bd5\uff09",
+			),
+			("\u00abhttps://m\u00fcnich.example/caf\u00e9\u00bb", "https://m\u00fcnich.example/caf\u00e9"),
+			("\u201chttps://example.com/\u8def\u5f84\u201d", "https://example.com/\u8def\u5f84"),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual([expected], _findUrls(text))
+
+	def testTrimsRepresentativeScriptSentencePunctuation(self) -> None:
+		"""Trim sentence punctuation used by representative writing systems."""
+		for character in (
+			"\u055d",
+			"\u0589",
+			"\u05c3",
+			"\u060c",
+			"\u061f",
+			"\u0964",
+			"\u0f0d",
+			"\u104b",
+			"\u1362",
+			"\u3002",
+			"\uff01",
+		):
+			with self.subTest(codePoint=f"U+{ord(character):04X}"):
+				self.assertEqual(
+					["https://example.com/path"],
+					_findUrls(f"https://example.com/path{character}"),
+				)
+
+	def testPreservesPairedInternationalDelimitersInsidePaths(self) -> None:
+		"""Preserve paired international delimiters in paths and trim them as outer wrappers."""
+		pairs = (
+			("\u00ab", "\u00bb"),
+			("\u2018", "\u2019"),
+			("\u201c", "\u201d"),
+			("\u2039", "\u203a"),
+			("\u3008", "\u3009"),
+			("\u300a", "\u300b"),
+			("\u300c", "\u300d"),
+			("\u300e", "\u300f"),
+			("\u3010", "\u3011"),
+			("\u3014", "\u3015"),
+			("\u3016", "\u3017"),
+			("\u3018", "\u3019"),
+			("\u301a", "\u301b"),
+			("\uff08", "\uff09"),
+			("\uff3b", "\uff3d"),
+			("\uff5b", "\uff5d"),
+			("\uff62", "\uff63"),
+		)
+		for opening, closing in pairs:
+			pathUrl = f"https://example.com/{opening}path{closing}"
+			with self.subTest(opening=opening, position="path"):
+				self.assertEqual([pathUrl], _findUrls(pathUrl))
+			with self.subTest(opening=opening, position="wrapper"):
+				self.assertEqual(
+					["https://example.com/path"],
+					_findUrls(f"{opening}https://example.com/path{closing}suffix"),
+				)
 
 
 class SourceCompatibilityTests(unittest.TestCase):

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -34,6 +34,26 @@ class FindUrlsTests(unittest.TestCase):
 			with self.subTest(text=text):
 				self.assertEqual(expected, _findUrls(text))
 
+	def testAllControlAndForbiddenRawCharactersTerminateCandidates(self) -> None:
+		"""Treat every C0/C1 control and forbidden raw ASCII character as a boundary."""
+		terminators = [chr(value) for value in range(0x00, 0x20)]
+		terminators.extend(chr(value) for value in range(0x7F, 0xA0))
+		terminators.extend('<>"\\^`{|}')
+		for character in terminators:
+			text = f"https://example.com{character}suffix"
+			with self.subTest(codePoint=f"U+{ord(character):04X}"):
+				self.assertEqual(["https://example.com"], _findUrls(text))
+				self.assertFalse(_isSupportedUrl(text))
+
+	def testUnicodeWhitespaceTerminatesCandidates(self) -> None:
+		"""Stop at representative non-ASCII whitespace characters."""
+		for character in ("\u00a0", "\u1680", "\u2000", "\u2028", "\u2029", "\u202f", "\u205f", "\u3000"):
+			with self.subTest(codePoint=f"U+{ord(character):04X}"):
+				self.assertEqual(
+					["https://example.com"],
+					_findUrls(f"https://example.com{character}suffix"),
+				)
+
 	def testBalancedDelimiters(self) -> None:
 		"""Preserve balanced URL delimiters and trim surrounding prose delimiters."""
 		cases = (
@@ -47,6 +67,41 @@ class FindUrlsTests(unittest.TestCase):
 			("https://example.com/a(b)))", ["https://example.com/a(b)"]),
 			("[http://[::1]]", ["http://[::1]"]),
 			("https://example.com/][]", ["https://example.com/][]"]),
+			("https://example.com/a((b))", ["https://example.com/a((b))"]),
+			("https://example.com/a[b[0]]", ["https://example.com/a[b[0]]"]),
+			("[http://[::1]/a[0]]", ["http://[::1]/a[0]"]),
+			("(https://example.com/a(b)).", ["https://example.com/a(b)"]),
+			("https://example.com/a[0]]);", ["https://example.com/a[0]"]),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual(expected, _findUrls(text))
+
+	def testTrimsOnlyTrailingProsePunctuation(self) -> None:
+		"""Trim established prose suffixes without removing punctuation inside URLs."""
+		cases = (
+			("https://example.com.", ["https://example.com"]),
+			("https://example.com,;'", ["https://example.com"]),
+			("https://example.com:([", ["https://example.com"]),
+			("https://example.com/a,b", ["https://example.com/a,b"]),
+			("https://example.com/a;b", ["https://example.com/a;b"]),
+			("https://example.com/a'b", ["https://example.com/a'b"]),
+			("https://example.com/a.b", ["https://example.com/a.b"]),
+			("https://example.com?", ["https://example.com?"]),
+			("https://example.com?#", ["https://example.com?#"]),
+		)
+		for text, expected in cases:
+			with self.subTest(text=text):
+				self.assertEqual(expected, _findUrls(text))
+
+	def testExtractsUrlsFromCommonMarkup(self) -> None:
+		"""Stop cleanly at HTML, Markdown, JSON, and plain-text boundaries."""
+		cases = (
+			('<a href="https://example.com/a?b=c#d">link</a>', ["https://example.com/a?b=c#d"]),
+			("[docs](https://example.com/a(b)).", ["https://example.com/a(b)"]),
+			('{"url": "https://example.com/a"}', ["https://example.com/a"]),
+			("https://one.example^https://two.example", ["https://one.example", "https://two.example"]),
+			("https://one.example\\https://two.example", ["https://one.example", "https://two.example"]),
 		)
 		for text, expected in cases:
 			with self.subTest(text=text):
@@ -66,6 +121,14 @@ class FindUrlsTests(unittest.TestCase):
 			with self.subTest(url=url):
 				self.assertEqual([], _findUrls(url))
 
+	def testSkipsInvalidCandidatesWithoutLosingLaterUrls(self) -> None:
+		"""Continue scanning after structurally invalid URL candidates."""
+		text = "http:///path https://example.com/%GG ftp://ftp.example.com/a www.example.com"
+		self.assertEqual(
+			["ftp://ftp.example.com/a", "www.example.com"],
+			_findUrls(text),
+		)
+
 	def testPreservesExistingBehavior(self) -> None:
 		"""Preserve case, Unicode, ordering, deduplication, and valid URL punctuation."""
 		unicodeUrl = "https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84"
@@ -80,6 +143,31 @@ class FindUrlsTests(unittest.TestCase):
 			["http://a", "https://example.com"],
 			_findUrls("http://a\nhttps://example.com"),
 		)
+
+	def testRequiresExactSupportedPrefixes(self) -> None:
+		"""Require a supported scheme separator or a literal dot after www."""
+		for text in (
+			"http:/example.com",
+			"https//example.com",
+			"ftp:/example.com",
+			"wwwXexample.com",
+			"www-example.com",
+			"www./path",
+			"www.:80",
+			"file://example.com",
+			"mailto:user@example.com",
+		):
+			with self.subTest(text=text):
+				self.assertEqual([], _findUrls(text))
+
+	def testHandlesLongInputs(self) -> None:
+		"""Handle long candidates and prefix-like text without changing the result."""
+		longUrl = "https://example.com/" + ("a" * 65536)
+		self.assertEqual([longUrl], _findUrls(longUrl))
+		self.assertEqual([longUrl], _findUrls(longUrl + (")" * 65536)))
+		balancedUrl = "https://example.com/" + ("(" * 512) + "a" + (")" * 512)
+		self.assertEqual([balancedUrl], _findUrls(balancedUrl))
+		self.assertEqual([], _findUrls("http:/" * 10000))
 
 
 class SupportedUrlTests(unittest.TestCase):
@@ -96,11 +184,39 @@ class SupportedUrlTests(unittest.TestCase):
 			"http://[v1.a]",
 			"http://[fe80::1%25eth0]/",
 			"https://\u4f8b\u5b50.\u4e2d\u56fd/\u8def\u5f84",
+			"http://127.0.0.1:0/",
+			"http://user@example.com/",
+			"http://example.com:00080/",
 			"http://example.com:65535/path",
+			"www.example.com:8080/path",
+			"https://example.com/!$&'()*+,;=:@",
+			"https://example.com/%00/%ff?x=%2F#fragment",
+			"https://example.com?#",
 		)
 		for url in validUrls:
 			with self.subTest(url=url):
 				self.assertTrue(_isSupportedUrl(url))
+
+	def testAcceptsEveryHexPercentEscape(self) -> None:
+		"""Accept every two-digit hexadecimal percent escape."""
+		hexDigits = "0123456789ABCDEF"
+		for firstDigit in hexDigits:
+			for secondDigit in hexDigits:
+				url = f"https://example.com/%{firstDigit}{secondDigit}"
+				with self.subTest(escape=url[-3:]):
+					self.assertTrue(_isSupportedUrl(url))
+					self.assertEqual([url], _findUrls(url))
+
+	def testPortBoundaries(self) -> None:
+		"""Accept only numeric ports in the range supported by URL parsing."""
+		for port in (0, 1, 80, 65535):
+			url = f"http://example.com:{port}/"
+			with self.subTest(port=port):
+				self.assertTrue(_isSupportedUrl(url))
+		for port in ("-1", "+1", "1.5", "abc", "65536", "99999999999999999999"):
+			url = f"http://example.com:{port}/"
+			with self.subTest(port=port):
+				self.assertFalse(_isSupportedUrl(url))
 
 	def testRejectsInvalidUrls(self) -> None:
 		"""Reject URLs with missing hosts, invalid ports, escapes, or raw delimiters."""
@@ -112,12 +228,47 @@ class SupportedUrlTests(unittest.TestCase):
 			"http://user@",
 			"http://[::1",
 			"http://[]",
+			"http://[:::]",
+			"http://[gggg::1]",
+			"http://[v.a]",
+			"http://::1",
 			"http://example.com:abc",
 			"http://example.com:65536",
 			"https://example.com/%",
 			"https://example.com/%0",
 			"https://example.com/%GG",
 			"https://example.com^suffix",
+		)
+		for url in invalidUrls:
+			with self.subTest(url=url):
+				self.assertFalse(_isSupportedUrl(url))
+
+	def testRejectsMalformedPercentEscapesEverywhere(self) -> None:
+		"""Reject incomplete or non-hexadecimal percent escapes in URL components."""
+		for escape in ("%", "%0", "%GG", "%0G", "%G0", "%%", "%-1"):
+			for template in (
+				"https://example.com/{}",
+				"https://example.com/?q={}",
+				"https://example.com/#{}",
+				"https://user{}@example.com/",
+			):
+				url = template.format(escape)
+				with self.subTest(url=url):
+					self.assertFalse(_isSupportedUrl(url))
+
+	def testRejectsUnsupportedSchemesAndMalformedAuthorities(self) -> None:
+		"""Reject unsupported schemes and authorities which cannot identify a host."""
+		invalidUrls = (
+			"file://example.com/path",
+			"nvdaremote://example.com",
+			"mailto:user@example.com",
+			"http:example.com",
+			"http:/example.com",
+			"https://?query",
+			"https://#fragment",
+			"www./path",
+			"http://example.com\uff0fpath",
+			"http://example.com\uff1a80",
 		)
 		for url in invalidUrls:
 			with self.subTest(url=url):

--- a/tests/unit/test_urlUtils.py
+++ b/tests/unit/test_urlUtils.py
@@ -2,6 +2,7 @@
 
 import ast
 from collections.abc import Callable
+from itertools import product
 from pathlib import Path
 import runpy
 from typing import cast
@@ -354,6 +355,71 @@ class SupportedUrlTests(unittest.TestCase):
 			with self.subTest(url=url):
 				self.assertTrue(_isSupportedUrl(url))
 
+	def testAcceptsAuthorityComponentCombinations(self) -> None:
+		"""Accept supported schemes, userinfo, hosts, ports, and suffixes in combination."""
+		schemes = ("http://", "https://", "ftp://")
+		userinfoValues = (
+			"",
+			"user@",
+			"user:pass@",
+			"user%20name:p%40ss@",
+			"\u7528\u6237:\u5bc6\u7801@",
+			"\U0001f464@",
+		)
+		hosts = (
+			"example.com",
+			"localhost",
+			"127.0.0.1",
+			"\u4f8b\u5b50.\u4e2d\u56fd",
+			"\U0001f453.ws",
+			"[::1]",
+		)
+		ports = ("", ":0", ":65535")
+		suffixes = ("", "/", "/path", "?q=value", "#fragment", "/\u8def\u5f84?q=\u503c#\u7247\u6bb5")
+		for scheme, userinfo, host, port, suffix in product(
+			schemes,
+			userinfoValues,
+			hosts,
+			ports,
+			suffixes,
+		):
+			url = f"{scheme}{userinfo}{host}{port}{suffix}"
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
+
+		for host, port, suffix in product(hosts[:-1], ports, suffixes):
+			url = f"www.{host}{port}{suffix}"
+			with self.subTest(url=url):
+				self.assertTrue(_isSupportedUrl(url))
+				self.assertEqual([url], _findUrls(url))
+
+	def testLaterAtSignsDoNotCrossAuthorityBoundaries(self) -> None:
+		"""Do not reinterpret text before an illegal userinfo character as credentials."""
+		boundaries = (
+			"[",
+			"]",
+			"<",
+			">",
+			'"',
+			"\\",
+			"^",
+			"`",
+			"{",
+			"|",
+			"}",
+			" ",
+			"\n",
+			"\u200b",
+			"\u200f",
+			"\uff5c",
+		)
+		for prefix, boundary in product(("http://", "https://", "ftp://", "www."), boundaries):
+			expected = f"{prefix}first.example"
+			text = f"{expected}{boundary}label@example.com"
+			with self.subTest(prefix=prefix, codePoint=f"U+{ord(boundary):04X}"):
+				self.assertEqual([expected], _findUrls(text))
+
 	def testAcceptsEveryHexPercentEscape(self) -> None:
 		"""Accept every two-digit hexadecimal percent escape."""
 		hexDigits = "0123456789ABCDEF"
@@ -584,7 +650,7 @@ class InternationalUrlTests(unittest.TestCase):
 			("\uff5b", "\uff5d"),
 			("\uff62", "\uff63"),
 		)
-		for opening, closing in pairs:
+		for pairIndex, (opening, closing) in enumerate(pairs):
 			pathUrl = f"https://example.com/{opening}path{closing}"
 			with self.subTest(opening=opening, position="path"):
 				self.assertEqual([pathUrl], _findUrls(pathUrl))
@@ -592,6 +658,19 @@ class InternationalUrlTests(unittest.TestCase):
 				self.assertEqual(
 					["https://example.com/path"],
 					_findUrls(f"{opening}https://example.com/path{closing}suffix"),
+				)
+
+			nestedOpening, nestedClosing = pairs[(pairIndex + 1) % len(pairs)]
+			nestedUrl = f"https://example.com/{opening}{nestedOpening}path{nestedClosing}{closing}"
+			with self.subTest(opening=opening, position="nestedPath"):
+				self.assertEqual([nestedUrl], _findUrls(nestedUrl))
+			with self.subTest(opening=opening, position="extraClosing"):
+				self.assertEqual([pathUrl], _findUrls(pathUrl + closing))
+			with self.subTest(opening=opening, position="sentencePunctuation"):
+				self.assertEqual([pathUrl], _findUrls(pathUrl + "\u3002"))
+			with self.subTest(opening=opening, position="extraOpening"):
+				self.assertEqual(
+					["https://example.com/path"], _findUrls("https://example.com/path" + opening)
 				)
 
 


### PR DESCRIPTION
## Summary

Replace the permissive URL extraction regex with shared URL matching and validation utilities.

The supported URL forms remain unchanged: HTTP, HTTPS, FTP, and bare `www.` URLs.

## Root cause

The previous regex treated URL prefixes and boundaries too loosely. It could merge adjacent links, include markup or prose punctuation, accept malformed destinations, mishandle multilingual separators, and repeatedly rescan the remaining text for comma-separated bare URLs.

## Changes

- Stop URLs correctly at HTML, Markdown, control-character, and prose boundaries.
- Preserve balanced parentheses and multilingual delimiters inside URL paths.
- Handle international hostnames, paths, queries, fragments, and sentence punctuation.
- Reject malformed hosts, ports, percent escapes, IPv6 addresses, and IPvFuture literals.
- Use the same validation for extracted text and focused link destinations.
- Make comma-separated bare `www.` matching scale linearly.
- Preserve NVDA 2021.1 and Python 3.7 compatibility without adding runtime dependencies.

Examples fixed:

- `wwwXexample.com` is no longer treated as a URL.
- `http://one.example,http://two.example` produces two URLs.
- `https://example.com</a>` stops before the HTML tag.
- `http://[:::]` and `http://example.com:70000` are rejected.
- International punctuation terminates authorities without removing valid Unicode path content.

## Performance

For 8,000 comma-separated bare `www.` URLs on the development machine:

- Before: approximately 5.18 seconds
- After: approximately 0.26 seconds

Runtime now scales approximately linearly.

## Testing

- 39 URL matching unit tests pass.
- Tested authority combinations across schemes, userinfo, Unicode hosts, ports, and suffixes.
- Tested control characters, multilingual punctuation, balanced delimiters, and percent escapes.
- Tested with Python 3.7 while `ipaddress` was unavailable, matching NVDA 2021.1 constraints.
- Compared 12,578 IP literals between the previous and replacement validators with no behavior differences.
- Ruff, C901, formatting, static compilation, and production-code Pyright checks pass.
- The rebuilt NVDA add-on package passed ZIP and source-content verification.