### PR TITLE
Use pre_speech to track the last spoken text

### DIFF
--- a/addon/globalPlugins/openLinkWith/__init__.py
+++ b/addon/globalPlugins/openLinkWith/__init__.py
@@ -161,7 +161,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self, *args, **kwargs):
 		super(GlobalPlugin, self).__init__(*args, **kwargs)
-		LastSpoken._patch()
+		LastSpoken.initialize()
 
 		if hasattr(gui.settingsDialogs, 'SettingsPanel'):
 			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(OpenLinkWithSettings)

--- a/addon/globalPlugins/openLinkWith/getlinks.py
+++ b/addon/globalPlugins/openLinkWith/getlinks.py
@@ -1,12 +1,8 @@
-# -*- coding: utf-8 -*-
-#this module is aimed to get the links under selected text, last spoken or in clipboard.
-# Code to get last spoken text is borrowed from speechHistory addon, thanks to James Scholes, Tyler Spivey and all contributors to that addon.
-
 import textInfos
 import api
 import ui
-import speech
-import speechViewer
+from speech.extensions import pre_speech
+from speech.speech import CHUNK_SEPARATOR
 
 from .urlUtils import findUrls
 
@@ -14,24 +10,26 @@ import addonHandler
 addonHandler.initTranslation()
 
 class LastSpoken:
-	''' Helper class that contains the code, to get last spoken text.'''
-	lastSpokenText=None
+	"""Track the most recent non-empty speech text."""
+
+	lastSpokenText = None
 
 	@classmethod
-	def _patch(cls):
-		cls.oldSpeak = speech.speech.speak
-		speech.speech.speak = cls.mySpeak
+	def initialize(cls):
+		"""Register the speech extension point handler."""
+		pre_speech.register(cls._onSpeech)
 
 	@classmethod
 	def terminate(cls):
-		speech.speech.speak = cls.oldSpeak
+		"""Unregister the speech extension point handler."""
+		pre_speech.unregister(cls._onSpeech)
 
 	@classmethod
-	def mySpeak(cls, sequence, *args, **kwargs):
-		cls.oldSpeak(sequence, *args, **kwargs)
-		text = speechViewer.SPEECH_ITEM_SEPARATOR.join([x for x in sequence if isinstance(x, str)])
-		if text.strip():
-			cls.lastSpokenText=text.strip()
+	def _onSpeech(cls, speechSequence):
+		"""Store the text from a speech sequence."""
+		text = CHUNK_SEPARATOR.join(item for item in speechSequence if isinstance(item, str)).strip()
+		if text:
+			cls.lastSpokenText = text
 
 
 def getClipText() -> str:

--- a/buildVars.py
+++ b/buildVars.py
@@ -40,7 +40,7 @@ Press the command you assotiated with the addon via input gestures, to display O
 	# Documentation file name
 	addon_docFileName="readme.html",
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
-	addon_minimumNVDAVersion="2021.1.0",
+	addon_minimumNVDAVersion="2024.2.0",
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
 	addon_lastTestedNVDAVersion="2026.1.0",
 	# Add-on update channel (default is None, denoting stable releases,


### PR DESCRIPTION
## Summary

- Replace the `speech.speak` monkey patch with the official `pre_speech` extension point.
- Use `CHUNK_SEPARATOR` when collecting text from speech sequences.
- Raise the minimum supported NVDA version from 2021.1 to 2024.2.

Using the extension point avoids replacing a core NVDA function, works safely alongside other add-ons, and provides reliable registration and cleanup when the add-on is loaded or unloaded.

## Testing

Manually tested the add-on and confirmed that extracting links from the last spoken text works as before.